### PR TITLE
Fix critical serial member initialisation.

### DIFF
--- a/include/ODriveArduino.h
+++ b/include/ODriveArduino.h
@@ -24,7 +24,7 @@ public:
      *
      * @param[in] serial The serial port to use to communicate with the ODrive
      */
-    ODriveArduino(const Stream& serial);
+    ODriveArduino(Stream& serial);
 
     /**
      * @brief Set the Position of a motor

--- a/src/ODriveArduino.cpp
+++ b/src/ODriveArduino.cpp
@@ -6,9 +6,8 @@
 template<class T> inline Print& operator <<(Print& obj, T arg) { obj.print(arg);    return obj; }
 template<>        inline Print& operator <<(Print& obj, float arg) { obj.print(arg, 4); return obj; }
 
-ODriveArduino::ODriveArduino(const Stream& serial) {
-    this->serial_ = serial;
-}
+ODriveArduino::ODriveArduino(Stream& serial)
+    : serial_(serial) {}
 
 void ODriveArduino::setPosition(int motor_number, float position, float velocity_feedforward, float torque_feedforward) {
     this->serial_ << "p " << motor_number << " " << position << " " << velocity_feedforward << " " << torque_feedforward << "\n";


### PR DESCRIPTION
The assignment of the `Serial` instance in the constructor is ineffective because a reference can only be initialised, not assigned. Thus, the constructor fails to initialise the `serial_` member. See this for a great explanation: https://stackoverflow.com/a/8636184/3697870

I have changed it to a traditional initialiser list like in the official library, and dropped the `const` since it's incompatible with references in this form.

I'd love to see this get pulled, since your library is really nicely packaged for use with PlatformIO and I'd prefer not to have to create patches. But as it is, this is the only thing that prevents the library's use.